### PR TITLE
Added 'Every Save' reload interval

### DIFF
--- a/JC2MapViewer/Window1.xaml
+++ b/JC2MapViewer/Window1.xaml
@@ -67,10 +67,11 @@
 				<Button Grid.Row="1" Grid.ColumnSpan="1" x:Name="reloadButton" Click="ReloadButton_Click" Visibility="{Binding ElementName=MainWindow, Path=SaveFileIsLoaded, Converter={StaticResource visibilityConverter}}">Reload</Button>
 				<ComboBox Grid.Row="1" Grid.Column="1" x:Name="reloadInterval" Visibility="{Binding ElementName=MainWindow, Path=SaveFileIsLoaded, Converter={StaticResource visibilityConverter}}" SelectionChanged="reloadInterval_SelectionChanged" >
 					<ComboBoxItem Content="Every minute"/>
-					<ComboBoxItem Content="Every 5 minutes" IsSelected="True"/>
+					<ComboBoxItem Content="Every 5 minutes"/>
 					<ComboBoxItem Content="Every 10 minutes"/>
 					<ComboBoxItem Content="Every 15 minutes"/>
 					<ComboBoxItem Content="Never"/>
+					<ComboBoxItem Content="Every save" IsSelected="True"/>
 				</ComboBox>
 				<ScrollViewer Grid.Row="2" Grid.ColumnSpan="2" VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Hidden">
 					<TreeView


### PR DESCRIPTION
Added 'Every Save' reload interval to reload the map every time any save file is modified. This allows both manual and autosaves to update the map.

I really liked the auto-update every interval feature, but when playing with the JC2MapViewer open, I want to see the map update after every settlement is completed. With the 'Every save' option, it attaches a FileSystemWatcher to the save directory to monitor for file changes, and updates the map whenever any save file is modified. This means that saves to different slots, including the autosave, all reload the map.