### PR TITLE
Retry file loading after a delay, if changed file is locked

### DIFF
--- a/JC2MapViewer/Window1.xaml.cs
+++ b/JC2MapViewer/Window1.xaml.cs
@@ -90,20 +90,20 @@ namespace JC2MapViewer
 
 		private void fileSystemWatcher_Changed(object sender, FileSystemEventArgs e)
 		{
-		    for (int i = 0; i < 5; i++)
-		    {
-		        try
-		        {
-		            _saveFile = new SaveFile(e.FullPath);
-		            Dispatcher.Invoke(new Action(loadSavedInfo));
-		            return;
-		        }
-                catch (IOException)
-		        {
-		            // the game is still updating the save file
-                    Thread.Sleep(TimeSpan.FromSeconds(i + 1));
-		        }
-		    }
+			for (int i = 0; i < 5; i++)
+			{
+				try
+				{
+					_saveFile = new SaveFile(e.FullPath);
+					Dispatcher.Invoke(new Action(loadSavedInfo));
+					return;
+				}
+				catch (IOException)
+				{
+					// the game is still updating the save file
+					Thread.Sleep(TimeSpan.FromSeconds(i + 1));
+				}
+			}
 		}
 
 		void Window1_Loaded( object sender, RoutedEventArgs e )

--- a/JC2MapViewer/Window1.xaml.cs
+++ b/JC2MapViewer/Window1.xaml.cs
@@ -20,6 +20,7 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.IO;
 using System.Linq;
+using System.Threading;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
@@ -89,15 +90,20 @@ namespace JC2MapViewer
 
 		private void fileSystemWatcher_Changed(object sender, FileSystemEventArgs e)
 		{
-			try
-			{
-				_saveFile = new SaveFile(e.FullPath);
-				Dispatcher.Invoke(new Action(loadSavedInfo));
-			}
-			catch (IOException)
-			{
-				// the game is still updating the save file
-			}
+		    for (int i = 0; i < 5; i++)
+		    {
+		        try
+		        {
+		            _saveFile = new SaveFile(e.FullPath);
+		            Dispatcher.Invoke(new Action(loadSavedInfo));
+		            return;
+		        }
+                catch (IOException)
+		        {
+		            // the game is still updating the save file
+                    Thread.Sleep(TimeSpan.FromSeconds(i + 1));
+		        }
+		    }
 		}
 
 		void Window1_Loaded( object sender, RoutedEventArgs e )


### PR DESCRIPTION
I've been finding that the "Every save" reload option is unreliable, and often misses saves. This is a simple change to try loading the save file multiple times.

Often the file is locked when the change event occurs, so we wait one second, try again, then wait two seconds, try again, etc.