### PR TITLE
Remove the need for the Refresh button

### DIFF
--- a/JC2MapViewer/Window1.xaml
+++ b/JC2MapViewer/Window1.xaml
@@ -17,7 +17,7 @@
 			</Style>
 			<HierarchicalDataTemplate x:Key="CheckBoxItemTemplate" ItemsSource="{Binding Children, Mode=OneTime}">
 				<StackPanel Orientation="Horizontal">
-					<CheckBox Focusable="False" IsChecked="{Binding IsChecked}" VerticalAlignment="Center" />
+					<CheckBox Focusable="False" IsChecked="{Binding IsChecked}" VerticalAlignment="Center" Checked="CheckBoxItem_Toggled" Unchecked="CheckBoxItem_Toggled" />
 					<TextBlock FontWeight="400" x:Name="Header">
 						<ContentPresenter Content="{Binding Text}" Margin="2,0" />
 					</TextBlock>
@@ -61,7 +61,6 @@
 					<RowDefinition Height="*"/>
 					<RowDefinition Height="Auto"/>
 					<RowDefinition Height="Auto"/>
-					<RowDefinition Height="Auto"/>
 				</Grid.RowDefinitions>
 				<Button Grid.ColumnSpan="2" x:Name="loadButton" Click="LoadButton_Click">Load Save File</Button>
 				<Button Grid.Row="1" Grid.ColumnSpan="1" x:Name="reloadButton" Click="ReloadButton_Click" Visibility="{Binding ElementName=MainWindow, Path=SaveFileIsLoaded, Converter={StaticResource visibilityConverter}}">Reload</Button>
@@ -81,10 +80,9 @@
 						ItemsSource="{Binding Mode=OneTime}"
 						ItemTemplate="{StaticResource CheckBoxItemTemplate}" />
 				</ScrollViewer>
-				<Button Grid.Row="3" Grid.ColumnSpan="2" x:Name="refreshButton" Click="RefreshButton_Click">Refresh</Button>
-				<ToggleButton Grid.Row="4" Grid.ColumnSpan="2" x:Name="toggleSettlementsButton" Click="ToggleSettlementsButton_Click">Toggle Settlements</ToggleButton>
-				<Button Grid.Row="5" x:Name="zoomInButton" Click="ZoomInButton_Click">Zoom In</Button>
-				<Button Grid.Row="5" Grid.Column="1" x:Name="zoomOutButton" Click="ZoomOutButton_Click">Zoom Out</Button>
+				<ToggleButton Grid.Row="3" Grid.ColumnSpan="2" x:Name="toggleSettlementsButton" Click="ToggleSettlementsButton_Click">Toggle Settlements</ToggleButton>
+				<Button Grid.Row="4" x:Name="zoomInButton" Click="ZoomInButton_Click">Zoom In</Button>
+				<Button Grid.Row="4" Grid.Column="1" x:Name="zoomOutButton" Click="ZoomOutButton_Click">Zoom Out</Button>
 			</Grid>
 		</Border>
 		<Border x:Name="errorBorder"

--- a/JC2MapViewer/Window1.xaml.cs
+++ b/JC2MapViewer/Window1.xaml.cs
@@ -329,7 +329,7 @@ namespace JC2MapViewer
 			}
 		}
 
-		private void RefreshButton_Click( object sender, RoutedEventArgs e )
+		private void CheckBoxItem_Toggled( object sender, RoutedEventArgs e )
 		{
 			if( _saveFile != null )
 			{

--- a/JC2MapViewer/Window1.xaml.cs
+++ b/JC2MapViewer/Window1.xaml.cs
@@ -44,7 +44,7 @@ namespace JC2MapViewer
 		bool _displaySettlements;
 		DispatcherTimer _dispatcherTimer = new DispatcherTimer();
 		FileSystemWatcher _fileSystemWatcher = new FileSystemWatcher() { NotifyFilter = NotifyFilters.LastWrite, Filter = "*.sav" };
-        ManualResetEvent _refreshRequested = new ManualResetEvent(false);
+		ManualResetEvent _refreshRequested = new ManualResetEvent(false);
 
 		public Window1()
 		{
@@ -274,7 +274,7 @@ namespace JC2MapViewer
 
 		private void loadSavedInfo()
 		{
-            ChooserViewModel root = itemChooser.Items[0] as ChooserViewModel;
+			ChooserViewModel root = itemChooser.Items[0] as ChooserViewModel;
 			List<string> categories = root.GetSelectedCategories();
 
 			map.ClearMarkers();
@@ -332,36 +332,36 @@ namespace JC2MapViewer
 		}
 
 		private void CheckBoxItem_Toggled( object sender, RoutedEventArgs e )
-        {
-            // Because multiple checkboxes might be toggled at the same time,
-            // we request a refresh then attempt to perform it, if necessary.
-		    _refreshRequested.Set();
-		    ThreadPool.QueueUserWorkItem(RefreshIfNecessary);
+		{
+			// Because multiple checkboxes might be toggled at the same time,
+			// we request a refresh then attempt to perform it, if necessary.
+			_refreshRequested.Set();
+			ThreadPool.QueueUserWorkItem(RefreshIfNecessary);
 		}
 
-        /// <summary>
-        /// Refreshes the map if a request is currently pending
-        /// </summary>
-        private void RefreshIfNecessary(object state) {
-            lock (this)
-            {
-                if (!_refreshRequested.WaitOne(0))
-                {
-                    // Refresh not necessary
-                    return;
-                }
+		/// <summary>
+		/// Refreshes the map if a request is currently pending
+		/// </summary>
+		private void RefreshIfNecessary(object state) {
+			lock (this)
+			{
+				if (!_refreshRequested.WaitOne(0))
+				{
+					// Refresh not necessary
+					return;
+				}
 
-                if (_saveFile != null)
-                {
-                    // Perform the refresh on the UI thread, so that we can update the map
-                    Action loadAction = loadSavedInfo;
-                    Dispatcher.Invoke(DispatcherPriority.Normal, loadAction);
-                }
+				if (_saveFile != null)
+				{
+					// Perform the refresh on the UI thread, so that we can update the map
+					Action loadAction = loadSavedInfo;
+					Dispatcher.Invoke(DispatcherPriority.Normal, loadAction);
+				}
 
-                // Clear the request
-                _refreshRequested.Reset();
-            }
-        }
+				// Clear the request
+				_refreshRequested.Reset();
+			}
+		}
 
 		private void ToggleSettlementsButton_Click( object sender, RoutedEventArgs e )
 		{

--- a/JC2MapViewer/Window1.xaml.cs
+++ b/JC2MapViewer/Window1.xaml.cs
@@ -20,6 +20,7 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.IO;
 using System.Linq;
+using System.Threading;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
@@ -43,6 +44,7 @@ namespace JC2MapViewer
 		bool _displaySettlements;
 		DispatcherTimer _dispatcherTimer = new DispatcherTimer();
 		FileSystemWatcher _fileSystemWatcher = new FileSystemWatcher() { NotifyFilter = NotifyFilters.LastWrite, Filter = "*.sav" };
+        ManualResetEvent _refreshRequested = new ManualResetEvent(false);
 
 		public Window1()
 		{
@@ -272,7 +274,7 @@ namespace JC2MapViewer
 
 		private void loadSavedInfo()
 		{
-			ChooserViewModel root = itemChooser.Items[0] as ChooserViewModel;
+            ChooserViewModel root = itemChooser.Items[0] as ChooserViewModel;
 			List<string> categories = root.GetSelectedCategories();
 
 			map.ClearMarkers();
@@ -330,12 +332,36 @@ namespace JC2MapViewer
 		}
 
 		private void CheckBoxItem_Toggled( object sender, RoutedEventArgs e )
-		{
-			if( _saveFile != null )
-			{
-				loadSavedInfo();
-			}
+        {
+            // Because multiple checkboxes might be toggled at the same time,
+            // we request a refresh then attempt to perform it, if necessary.
+		    _refreshRequested.Set();
+		    ThreadPool.QueueUserWorkItem(RefreshIfNecessary);
 		}
+
+        /// <summary>
+        /// Refreshes the map if a request is currently pending
+        /// </summary>
+        private void RefreshIfNecessary(object state) {
+            lock (this)
+            {
+                if (!_refreshRequested.WaitOne(0))
+                {
+                    // Refresh not necessary
+                    return;
+                }
+
+                if (_saveFile != null)
+                {
+                    // Perform the refresh on the UI thread, so that we can update the map
+                    Action loadAction = loadSavedInfo;
+                    Dispatcher.Invoke(DispatcherPriority.Normal, loadAction);
+                }
+
+                // Clear the request
+                _refreshRequested.Reset();
+            }
+        }
 
 		private void ToggleSettlementsButton_Click( object sender, RoutedEventArgs e )
 		{


### PR DESCRIPTION
I often confuse the Refresh and Reload buttons.

This change removes the need for the Refresh button, by automatically refreshing the map as the checkboxes are toggled in the tree view.