### PR TITLE
Try to locate the current Steam user's JC2 save folder

### DIFF
--- a/JC2MapViewer/Window1.xaml.cs
+++ b/JC2MapViewer/Window1.xaml.cs
@@ -309,7 +309,7 @@ namespace JC2MapViewer
 			try
 			{
 				OpenFileDialog dlg = new OpenFileDialog();
-			    dlg.InitialDirectory = GetJC2SaveFolderPath() ?? "";
+				dlg.InitialDirectory = GetJC2SaveFolderPath() ?? "";
 				dlg.Filter = "Just Cause 2 Save (.sav)|*.sav";
 				Nullable<bool> result = dlg.ShowDialog();
 				if( result == true )
@@ -331,52 +331,52 @@ namespace JC2MapViewer
 			}
 		}
 
-        /// <summary>
-        /// Determines the location of Just Cause 2 save files for the first Steam user on this computer.
-        /// If there are multiple Steam users that play Just Cause 2, only the first folder will be returned.
-        /// </summary>
-        /// <returns>The Steam Cloud folder for Just Cause 2, or null, if it was not located</returns>
-        private static string GetJC2SaveFolderPath()
-        {
-            try
-            {
-                // Find where Steam is installed. 64 bit versions of Windows will redirect it to the Wow6432Node location
-                string installPath32 = Registry.GetValue(@"HKEY_LOCAL_MACHINE\SOFTWARE\Valve\Steam", "InstallPath", null) as string;
-                string installPath64 = Registry.GetValue(@"HKEY_LOCAL_MACHINE\SOFTWARE\Wow6432Node\Valve\Steam", "InstallPath", null) as string;
-                string installPath = installPath32 ?? installPath64;
-                if (installPath == null)
-                {
-                    return null;
-                }
+		/// <summary>
+		/// Determines the location of Just Cause 2 save files for the first Steam user on this computer.
+		/// If there are multiple Steam users that play Just Cause 2, only the first folder will be returned.
+		/// </summary>
+		/// <returns>The Steam Cloud folder for Just Cause 2, or null, if it was not located</returns>
+		private static string GetJC2SaveFolderPath()
+		{
+			try
+			{
+				// Find where Steam is installed. 64 bit versions of Windows will redirect it to the Wow6432Node location
+				string installPath32 = Registry.GetValue(@"HKEY_LOCAL_MACHINE\SOFTWARE\Valve\Steam", "InstallPath", null) as string;
+				string installPath64 = Registry.GetValue(@"HKEY_LOCAL_MACHINE\SOFTWARE\Wow6432Node\Valve\Steam", "InstallPath", null) as string;
+				string installPath = installPath32 ?? installPath64;
+				if (installPath == null)
+				{
+					return null;
+				}
 
-                // Find the Steam user data folder
-                string userDataPath = Path.Combine(installPath, "userdata");
-                var userData = new DirectoryInfo(userDataPath);
+				// Find the Steam user data folder
+				string userDataPath = Path.Combine(installPath, "userdata");
+				var userData = new DirectoryInfo(userDataPath);
 
-                // Find the different Steam users accounts
-                foreach (DirectoryInfo userFolder in userData.GetDirectories())
-                {
-                    // Check if this Steam user has Just Cause 2 data
-                    DirectoryInfo jc2DataFolder = userFolder.GetDirectories("8190").FirstOrDefault();
-                    if (jc2DataFolder != null)
-                    {
-                        // Find the Steam Cloud folder, which stores the save games
-                        DirectoryInfo steamCloudFolder = jc2DataFolder.GetDirectories("remote").FirstOrDefault();
-                        if (steamCloudFolder != null)
-                        {
-                            return steamCloudFolder.FullName;
-                        }
-                    }
-                }
-            }
-            catch
-            {
-                // Unable to determine location automatically
-            }
-            return null;
-        }
+				// Find the different Steam users accounts
+				foreach (DirectoryInfo userFolder in userData.GetDirectories())
+				{
+					// Check if this Steam user has Just Cause 2 data
+					DirectoryInfo jc2DataFolder = userFolder.GetDirectories("8190").FirstOrDefault();
+					if (jc2DataFolder != null)
+					{
+						// Find the Steam Cloud folder, which stores the save games
+						DirectoryInfo steamCloudFolder = jc2DataFolder.GetDirectories("remote").FirstOrDefault();
+						if (steamCloudFolder != null)
+						{
+							return steamCloudFolder.FullName;
+						}
+					}
+				}
+			}
+			catch
+			{
+				// Unable to determine location automatically
+			}
+			return null;
+		}
 
-        private void RefreshButton_Click( object sender, RoutedEventArgs e )
+		private void RefreshButton_Click( object sender, RoutedEventArgs e )
 		{
 			if( _saveFile != null )
 			{

--- a/JC2MapViewer/Window1.xaml.cs
+++ b/JC2MapViewer/Window1.xaml.cs
@@ -31,6 +31,7 @@ using BruTile.Cache;
 using BruTile.UI;
 using BruTile.UI.Windows;
 using JC2.Save;
+using Microsoft.Win32;
 
 namespace JC2MapViewer
 {
@@ -307,7 +308,8 @@ namespace JC2MapViewer
 		{
 			try
 			{
-				Microsoft.Win32.OpenFileDialog dlg = new Microsoft.Win32.OpenFileDialog();
+				OpenFileDialog dlg = new OpenFileDialog();
+			    dlg.InitialDirectory = GetJC2SaveFolderPath() ?? "";
 				dlg.Filter = "Just Cause 2 Save (.sav)|*.sav";
 				Nullable<bool> result = dlg.ShowDialog();
 				if( result == true )
@@ -329,7 +331,52 @@ namespace JC2MapViewer
 			}
 		}
 
-		private void RefreshButton_Click( object sender, RoutedEventArgs e )
+        /// <summary>
+        /// Determines the location of Just Cause 2 save files for the first Steam user on this computer.
+        /// If there are multiple Steam users that play Just Cause 2, only the first folder will be returned.
+        /// </summary>
+        /// <returns>The Steam Cloud folder for Just Cause 2, or null, if it was not located</returns>
+        private static string GetJC2SaveFolderPath()
+        {
+            try
+            {
+                // Find where Steam is installed. 64 bit versions of Windows will redirect it to the Wow6432Node location
+                string installPath32 = Registry.GetValue(@"HKEY_LOCAL_MACHINE\SOFTWARE\Valve\Steam", "InstallPath", null) as string;
+                string installPath64 = Registry.GetValue(@"HKEY_LOCAL_MACHINE\SOFTWARE\Wow6432Node\Valve\Steam", "InstallPath", null) as string;
+                string installPath = installPath32 ?? installPath64;
+                if (installPath == null)
+                {
+                    return null;
+                }
+
+                // Find the Steam user data folder
+                string userDataPath = Path.Combine(installPath, "userdata");
+                var userData = new DirectoryInfo(userDataPath);
+
+                // Find the different Steam users accounts
+                foreach (DirectoryInfo userFolder in userData.GetDirectories())
+                {
+                    // Check if this Steam user has Just Cause 2 data
+                    DirectoryInfo jc2DataFolder = userFolder.GetDirectories("8190").FirstOrDefault();
+                    if (jc2DataFolder != null)
+                    {
+                        // Find the Steam Cloud folder, which stores the save games
+                        DirectoryInfo steamCloudFolder = jc2DataFolder.GetDirectories("remote").FirstOrDefault();
+                        if (steamCloudFolder != null)
+                        {
+                            return steamCloudFolder.FullName;
+                        }
+                    }
+                }
+            }
+            catch
+            {
+                // Unable to determine location automatically
+            }
+            return null;
+        }
+
+        private void RefreshButton_Click( object sender, RoutedEventArgs e )
 		{
 			if( _saveFile != null )
 			{


### PR DESCRIPTION
By default, the Load Save File dialog opens to the user's Documents folder, but this is not where the Just Cause 2 save files are usually located.

This change looks up the location of the Steam folder from the Windows Registry, then tries to locate the first Steam user data folder that contains Just Cause 2 save files. This means that the dialog opens to the correct folder by default.

It's possible that if there are other Steam users on the same machine playing Just Cause 2, they may need to browse to find their save files, but that would only involve going up the folder hierarchy a couple of steps.
